### PR TITLE
Remove 'version' from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "marked",
-  "version": "0.3.4",
   "homepage": "https://github.com/chjj/marked",
   "authors": [
     "Christopher Jeffrey <chjjeffrey@gmail.com>"


### PR DESCRIPTION
This field is obsolete and not used by bower, but the inconsistency between the value and the tag/package.json entry will lead to warnings on the console.